### PR TITLE
share 'post' templates between client and server

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,6 +40,8 @@ app.get('/uisandbox', function(request, response){
   response.render('posts/show');
 });
 
+app.use('/templates/post', express.static(__dirname + '/app/views/posts/'));
+
 app.locals({
   posts: [
     {

--- a/app/assets/javascripts/jade-runtime.js
+++ b/app/assets/javascripts/jade-runtime.js
@@ -1,0 +1,1 @@
+../../../node_modules/jade/runtime.js

--- a/app/views/application.jade
+++ b/app/views/application.jade
@@ -35,6 +35,7 @@ html(lang="en")
     script(src="javascripts/socket.io.js")
     script(src="javascripts/moment.js")
     script(src="javascripts/underscore.js")
+    script(src="javascripts/jade-runtime.js")
     script(src="javascripts/jquery.js")
     #posts
     script.

--- a/app/views/posts/new.jade
+++ b/app/views/posts/new.jade
@@ -1,25 +1,15 @@
-script#post(type="text/template").
-  <section class="post">
-    <div class="meta clearfix">
-      <div class="username datum"><%= user %></div>
-      <div class="time datum">
-        <i class="fa fa-clock-o"></i>
-        <%= date %>
-      </div>
-    </div>
-    <div class="content"><%= body %></div>
-  </section>
+script(src="/templates/post/post.js")
 
 .new
   form
     input(type="text")
   script.
     socket.on('post', function(response){
-      $('#main').prepend(_.template($('#post').html())({
-        user: 'Jim',
-        date: moment(response.date).fromNow(),
-        body: response.body
-      }));
+      var locals = {};
+      locals.post = response;
+      locals.post.date = moment(locals.post.date).fromNow();
+      locals.post.user = 'Jim';
+      $('#main').prepend(anonymous(locals));
     });
 
     $('.new form').submit(function(event){

--- a/app/views/posts/post.jade
+++ b/app/views/posts/post.jade
@@ -1,0 +1,7 @@
+section.post
+  .meta.clearfix
+    .username.datum=post.user
+    .time.datum
+      i.fa.fa-clock-o
+      = post.date
+  .content!=post.body

--- a/app/views/posts/post.js
+++ b/app/views/posts/post.js
@@ -1,0 +1,4 @@
+function anonymous(locals) {
+var buf = [];
+var locals_ = (locals || {}),post = locals_.post;buf.push("<section class=\"post\"><div class=\"meta clearfix\"><div class=\"username datum\">" + (jade.escape(null == (jade.interp = post.user) ? "" : jade.interp)) + "</div><div class=\"time datum\"><i class=\"fa fa-clock-o\"></i>" + (jade.escape(null == (jade.interp = post.date) ? "" : jade.interp)) + "</div></div><div class=\"content\">" + (null == (jade.interp = post.body) ? "" : jade.interp) + "</div></section>");;return buf.join("");
+}

--- a/app/views/posts/show.jade
+++ b/app/views/posts/show.jade
@@ -2,10 +2,4 @@ extends ../application
 
 block main
   each post in posts
-    section.post
-      .meta.clearfix
-        .username.datum=post.user
-        .time.datum
-          i.fa.fa-clock-o
-          = post.date
-      .content!=post.body
+    include post


### PR DESCRIPTION
fixes #5. we could probably make it more elegant if we have other markup templates that we need to share in the future, but this seems good for _right now_.
