### PR TITLE
in test environment, make DATABASE_URL setting explicit (via test_helper...

### DIFF
--- a/config/environments.js
+++ b/config/environments.js
@@ -10,7 +10,6 @@ module.exports = function(app){
   });
 
   app.configure('test', function(){
-    process.env.DATABASE_URL = "postgres://postgres@localhost/forum_test";
     // test environment-specific stuff here:
   });
 

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,2 +1,6 @@
+if (process.env.NODE_ENV === 'test') {
+  process.env.DATABASE_URL = "postgres://postgres@localhost/forum_test";
+}
+
 require('../lib/helpers');
 


### PR DESCRIPTION
(via `test_helper.js`). DATABASE_URL setting for test environment is no longer dependent on `config/environments.js`.

fixes #45 
