### PR TITLE
Use sequelize 2.x.x final

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jquery": "2.1.3",
     "velocity-animate": "~1.1.0",
     "pg": "~2.11.1",
-    "sequelize": "2.0.0-rc7",
+    "sequelize": "^2.0.3",
     "connect-pg-simple": "^2.1.1",
     "passport": "~0.2.0",
     "passport-local": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jquery": "2.1.3",
     "velocity-animate": "~1.1.0",
     "pg": "~2.11.1",
+    "pg-hstore": "^2.3.1",
     "sequelize": "^2.0.3",
     "connect-pg-simple": "^2.1.1",
     "passport": "~0.2.0",


### PR DESCRIPTION
just a version bump.

special caveat here: sequelize recently added `pg-hstore` as an _implicit_ dependency if you're using sequelize with postgres.