### PR TITLE
topic listing page optimization

### DIFF
--- a/app/controllers/PostsController.js
+++ b/app/controllers/PostsController.js
@@ -41,23 +41,7 @@ var PostsController = {
   },
 
   topics: function(limit){
-    // get posts without a parent.
-    // consider these as 'topics'
-    return post.findAll({
-      where: ['"post"."parent" isnull'],
-      include: [
-        user,
-        {
-          model: post,
-          as: 'children',
-          include: [user]
-        }
-      ],
-      order: [
-        ['created_at', 'DESC'],
-        [{model: post, as: 'children'}, 'created_at', 'DESC']
-      ]
-    });
+    return post.findTopicsAndMetadata();
   },
 
   postsForTopic: function(lastVisited, topicID, limit){

--- a/app/models/Post.orm.js
+++ b/app/models/Post.orm.js
@@ -28,6 +28,24 @@ var PostSequelize = function(sequelize){
         });
       },
 
+      findTopicsAndMetadata: function() {
+        return sequelize.query('select title, id, (select count(id) from post where (parent=topic.id)) as replyCount, (select id from post where (parent=topic.id) order by created_at desc limit 1) as "lastreply.id", coalesce((select created_at from post where (parent=topic.id) order by created_at desc limit 1), created_at) as "lastreply.created_at", coalesce((select name from forum_user where (id=  (select user_id from post where (parent=topic.id) order by created_at desc limit 1)) order by created_at desc limit 1), (select name from forum_user where (id=topic.user_id))) as "lastreply.user.name", created_at from post as topic where (parent isnull) order by "lastreply.created_at" desc',
+          {
+            nest: true,
+            raw: true
+          }
+        );
+      },
+
+      findTopics: function() {
+        return sequelize.query(
+          'select title, id, (select created_at from post where (parent=topic.id) order by created_at desc limit 1) as "lastreply.created_at", created_at from post as topic where (parent isnull) order by "lastreply.created_at" desc',
+          {
+            nest: true,
+            raw: true
+          }
+        );
+      },
       countTopics: function() {
         return sequelize.query(
           'select count(*) from post where parent isnull'

--- a/app/views/posts/topic.jade
+++ b/app/views/posts/topic.jade
@@ -7,12 +7,12 @@
           i.fa.fa-file-o
     .extra
       a.replies(href='/topic/' + post.id)
-        span.count= post.children.length
+        span.count= post.replycount
         |  Replies.
-      .username.datum=post.children[0] && post.children[0].user && post.children[0].user.name || post.user.name
+      .username.datum=post.lastreply && post.lastreply.user.name
       a.time.datum(href='/topic/' + post.id + '#reply')
         i.fa.fa-clock-o
-        .distance(data-timestamp=getPostDate(post).toString())= moment(getPostDate(post)).fromNow()
+        .distance(data-timestamp=post.lastreply.created_at)= moment(post.lastreply.created_at).fromNow()
   .actions
     a.action.reply(href='/topic/' + post.id + '#reply')
       .context

--- a/config/routes.js
+++ b/config/routes.js
@@ -56,14 +56,6 @@ var routes = function(app, passport){
       var limit = request.query.all ? 'ALL' : 7;
 
       PostsController.topics().done(function(error, posts){
-        posts = _.first(_.sortBy(posts, function(post) {
-          if (post.children[0]) {
-            return post.children[0].created_at;
-          }
-
-          return post.created_at;
-        }).reverse(), limit === 'ALL' ? posts.length : limit);
-
         response.render('index', {
           posts: posts,
           count: countResult[0].count,

--- a/config/routes.js
+++ b/config/routes.js
@@ -29,6 +29,17 @@ var routes = function(app, passport){
       return next();
     }
 
+
+    var assetPaths = ['stylesheets', 'javascripts', 'templates', 'fonts', 'images'];
+
+    // skip "last visited" lookup if the request is obviously just for an asset:
+    for (var i = 0; i < assetPaths.length; i++) {
+      if (request.originalUrl.indexOf(assetPaths[i]) !== -1) {
+        return next();
+      }
+    }
+
+
     UserController.getLastVisited(request.session.user.id).then(function(lastVisited) {
       response.locals.lastVisited = lastVisited || {};
 


### PR DESCRIPTION
1. first commit is actually a rider. it ensures that we don't do too many lookups for 'thread last visited' info. this used to happen on every request, including asset requests. now it no longer happens for requests that are obviously asset requests. this change affects all pages/requests.
2. built up a query that will return the data we want on the "topics" page/logged-in index. it's a bit of a monster (many subqueries) but it's an order of magnitude faster than the query that sequelize was generating. fixes #144. in the future we _might_ want to do multiple individual queries and then combine them all after they've all come back instead of putting a bunch of subqueries here. that would be nice to consider particularly if it's faster than what this changeset introduces.