### PR TITLE
handful of fixes around new thread creation:

### DIFF
--- a/app/components/NewPost.jsx
+++ b/app/components/NewPost.jsx
@@ -36,11 +36,15 @@ var NewPost = React.createClass({
 
   },
 
+  hasTitle: function() {
+    return ReactDOM.findDOMNode(this.refs.title);
+  },
+
   getTitle: function() {
-    var titleNode = ReactDOM.findDOMNode(this.refs.title);
+    var titleNode = this.hasTitle();
 
     if (titleNode) {
-      return titleNode.value;
+      return titleNode.value.trim();
     }
   },
 
@@ -68,6 +72,11 @@ var NewPost = React.createClass({
     if (!postBody) {
       return false;
     }
+
+    if (this.hasTitle() && !this.getTitle()) {
+      return false;
+    }
+
 
     this.setState({
       restrictSubmit: true

--- a/app/components/NewPost.jsx
+++ b/app/components/NewPost.jsx
@@ -36,6 +36,14 @@ var NewPost = React.createClass({
 
   },
 
+  getTitle: function() {
+    var titleNode = ReactDOM.findDOMNode(this.refs.title);
+
+    if (titleNode) {
+      return titleNode.value;
+    }
+  },
+
   bodyMassage: function(body, author) {
      return `
       > ${author} wrote:
@@ -67,7 +75,7 @@ var NewPost = React.createClass({
 
     window.socket.emit('post', {
       parent: this.props.parent,
-      title: this.refs.title && this.refs.title.value,
+      title: this.getTitle(),
       body: postBody,
       user: {
         id: window.forum.constants.user.id,

--- a/app/components/Root.jsx
+++ b/app/components/Root.jsx
@@ -9,7 +9,7 @@ var ControlBar = require('./ControlBar.jsx');
 var Root = React.createClass({
   getTitle: function(props) {
     var thread = _.find(props.value.topics, {
-      id: parseInt(props.params.id, 10)
+      id: +props.params.id
     });
 
     if (thread && thread.title) {

--- a/app/components/ShowPost.jsx
+++ b/app/components/ShowPost.jsx
@@ -24,7 +24,7 @@ module.exports = React.createClass({
       });
     }
 
-    superagent.get(`/topic/${parseInt(this.props.routeParams.id, 10)}`)
+    superagent.get(`/topic/${+this.props.routeParams.id}`)
       .set('Accept', 'application/json')
       .then(function(response){
         this.setState({

--- a/app/components/ShowTopic.jsx
+++ b/app/components/ShowTopic.jsx
@@ -17,6 +17,14 @@ module.exports = React.createClass({
     });
   },
 
+  getTopicPosts: function() {
+    if (this.getExistingChildren().length < 20) {
+      return _.filter(this.props.value.topics, {id: +this.props.routeParams.id}).concat(this.getExistingChildren());
+    }
+
+    return this.getExistingChildren();
+  },
+
   componentWillMount: function() {
     // if the user has mounted before, they'll have
     // many existing children, so we shouldn't
@@ -78,11 +86,7 @@ module.exports = React.createClass({
           {...topicData}
           loadMore={this.loadMore}
           renderLoadMore={this.renderLoadMore}
-          posts={_.filter(this.props.value.topics,
-            {
-              parent: parseInt(this.props.routeParams.id, 10)
-            }
-          )}
+          posts={this.getTopicPosts()}
         />
         <Loader />
       </div>

--- a/app/components/ShowTopic.jsx
+++ b/app/components/ShowTopic.jsx
@@ -13,7 +13,7 @@ module.exports = React.createClass({
 
   getExistingChildren: function() {
     return _.filter(window.store.getState().topics, {
-      parent: parseInt(this.props.routeParams.id, 10)
+      parent: +this.props.routeParams.id
     });
   },
 
@@ -37,7 +37,7 @@ module.exports = React.createClass({
 
   handleLoadMore: function() {
     document.body.classList.add('is-loading');
-    superagent.get(`/topic/${parseInt(this.props.routeParams.id, 10)}?limit=20&offset=${this.state.offset}`)
+    superagent.get(`/topic/${+this.props.routeParams.id}?limit=20&offset=${this.state.offset}`)
       .set('Accept', 'application/json')
       .then(function(response){
         window.store.dispatch({
@@ -69,7 +69,7 @@ module.exports = React.createClass({
 
   render: function() {
     var topicData = _.find(this.props.value.topics, {
-      id: parseInt(this.props.routeParams.id, 10)
+      id: +this.props.routeParams.id
     });
 
     return (

--- a/app/components/ShowTopic.jsx
+++ b/app/components/ShowTopic.jsx
@@ -12,7 +12,7 @@ module.exports = React.createClass({
   },
 
   getExistingChildren: function() {
-    return _.filter(window.store.getState().topics, {
+    return _.filter(this.props.value.topics, {
       parent: +this.props.routeParams.id
     });
   },

--- a/app/reducer-topics.js
+++ b/app/reducer-topics.js
@@ -73,7 +73,7 @@ module.exports = function doPosts(state, action) {
         id: newPost.parent
       });
       parentPost.lastreply = newPost;
-      parentPost.replycount = parseInt(parentPost.replycount, 10) + 1;
+      parentPost.replycount = +parentPost.replycount + 1;
     }
 
     return newState;

--- a/app/reducer-topics.js
+++ b/app/reducer-topics.js
@@ -42,6 +42,16 @@ module.exports = function doPosts(state, action) {
   }
 
   if (action.type === 'BACKFILL') {
+    if (action.value.length === 1) {
+      const postIndex = state.findIndex(function(element) {
+        return element.id === action.value[0].id;
+      });
+
+      let newState = state.slice(0, postIndex).concat(action.value, state.slice(postIndex + 1))
+
+      return newState;
+    }
+
     return action.value.concat(state);
   }
 


### PR DESCRIPTION
- fix titles in new threads (94c1c1b479)
- fix new thread double-display issue (74210636)

handful of minor refactorings too.

example: instead of `parseInt`, we can just prepend strings with a `+` to turn them into numbers. in all of these places we expect an int, and a float would break things, but there's no way we'd get a float in any of these places.