### PR TITLE
Add link to parent thread in ThreadPost's actionContainer

### DIFF
--- a/app/components/ThreadPost.jsx
+++ b/app/components/ThreadPost.jsx
@@ -142,6 +142,28 @@ module.exports = createReactClass({
     );
   },
 
+  renderThread: function() {
+    if (this.props.parent) {
+      return (
+        <Link
+          className="action"
+          to={`/topic/${this.props.parent}`}
+        >
+          Thread
+        </Link>
+      );
+    } else {
+      return (
+        <Link
+          className="action"
+          to={`/topic/${this.props.id}`}
+        >
+          Thread
+        </Link>
+      );
+    }
+  },
+
   handleDelete: function() {
     this.setState({
       showDelete: false
@@ -315,6 +337,7 @@ module.exports = createReactClass({
           Link
         </Link>
 
+        {this.renderThread()}
         {this.renderEdit()}
         {this.renderDelete()}
       </div>

--- a/app/components/ThreadPost.jsx
+++ b/app/components/ThreadPost.jsx
@@ -152,16 +152,15 @@ module.exports = createReactClass({
           Thread
         </Link>
       );
-    } else {
-      return (
-        <Link
-          className="action"
-          to={`/topic/${this.props.id}`}
-        >
-          Thread
-        </Link>
-      );
     }
+    return (
+      <Link
+        className="action"
+        to={`/topic/${this.props.id}`}
+      >
+        Thread
+      </Link>
+    );
   },
 
   handleDelete: function() {

--- a/stylesheets/v2-neoclassical.css
+++ b/stylesheets/v2-neoclassical.css
@@ -55,6 +55,7 @@ body {
 }
 
 .post .actionContainer {
+  font-size: 0.8em;
   padding: 1em 1em 2em;
   position: absolute;
   width: 100%;


### PR DESCRIPTION
This new link in the actionContainer will link to the post's parent thread (duplicating the existing "Link" in the case of the first post in the thread). Most useful for searching, when we lose the thread context.

Shrinks the font size of actionContainer a bit to fit all the action links on one line on mobile. Screenshot is 360px wide.

![](https://i.imgur.com/XjCFcXD.png)