### PR TITLE
correct ellipsis and paperclip color in dark theme

### DIFF
--- a/stylesheets/v2-classic-dark.css
+++ b/stylesheets/v2-classic-dark.css
@@ -45,6 +45,10 @@ body {
   box-shadow: 0 0 5px black inset;
 }
 
+.inlineAction {
+  color: #d9d9d9;
+}
+
 .input--secondary {
   color: #00bbff;
   box-shadow: 0 0 2px black;
@@ -59,7 +63,7 @@ body {
 }
 
 .paperclip {
-  filter: invert(0.6);
+  filter: invert(0.85);
 }
 
 .post {

--- a/stylesheets/v2-classic-dark.css
+++ b/stylesheets/v2-classic-dark.css
@@ -46,7 +46,7 @@ body {
 }
 
 .inlineAction {
-  color: #d9d9d9;
+  color: inherit;
 }
 
 .input--secondary {


### PR DESCRIPTION
I updated the ellipsis to match the body text and changed the paperclip slightly to match it as best as possible using `filter: invert()`. If we wanted an exact match we could inline the SVG and color it directly or something instead.

Screenshots: https://imgur.com/a/WXmEiPw